### PR TITLE
Fix unpacking of mainnetdb

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -201,7 +201,7 @@ This has been added recently (21 December 2017) so please contact me on `github 
 
 .. code:: bash
 
-   cd /tmp && curl -LO https://x-vps.com/iota.db.tgz && systemctl stop iri && rm -rf /var/lib/iri/target/mainnetdb* && pv iota.db.tgz | tar xzf - -C /var/lib/iri/target/ && chown iri.iri /var/lib/iri -R && rm -f /tmp/iota.db.tgz && systemctl start iri
+   cd /tmp && curl -LO https://x-vps.com/iota.db.tgz && systemctl stop iri && rm -rf /var/lib/iri/target/mainnetdb* && mkdir /var/lib/iri/target/mainnetdb/ && pv iota.db.tgz | tar xzf - -C /var/lib/iri/target/mainnetdb/ && chown iri.iri /var/lib/iri -R && rm -f /tmp/iota.db.tgz && systemctl start iri
 
 
 .. raw:: html


### PR DESCRIPTION
The db files extracted straight into the target folder and not into the mainnetdb subfolder. After deleting mainnetdb* it recreates the folder and extracts its right into it